### PR TITLE
Adding in the option for a shortVersionString

### DIFF
--- a/glitter.gemspec
+++ b/glitter.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.name        = "glitter"
   s.version     = Glitter::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Brad Gessler"]
-  s.email       = ["brad@polleverywhere.com"]
+  s.authors     = ["Brad Gessler, Thomas Hanley"]
+  s.email       = ["brad@polleverywhere.com, tom@lytro.com"]
   s.homepage    = "https://github.com/polleverywhere/glitter"
   s.summary     = %q{Publish Mac software updates with the Sparkle framework and Amazon S3.}
   s.description = %q{Glitter makes it easy to publish software updates via the Sparkle framework by using S3 buckets.}

--- a/lib/glitter.rb
+++ b/lib/glitter.rb
@@ -48,7 +48,7 @@ module Glitter
     AppcastXml = 'appcast.xml'
 
     include Configurable
-    attr_configurable :name, :version, :notes, :archive, :s3
+    attr_configurable :name, :version, :shortVersionString, :notes, :archive, :s3
 
     class S3
       include Configurable
@@ -111,6 +111,7 @@ module Glitter
       @assets ||= Hash.new do |hash,key|
         hash[key] = Asset.new do |r|
           r.version = key
+          r.shortVersionString = shortVersionString
           r.notes = notes
           r.app = self
         end
@@ -119,7 +120,7 @@ module Glitter
   end
 
   class Asset
-    attr_accessor :app, :version, :notes, :published_at, :object
+    attr_accessor :app, :version, :shortVersionString, :notes, :published_at, :object
 
     def initialize
       @published_at = Time.now
@@ -153,6 +154,7 @@ module Glitter
       @head ||= self.class.new do |a|
         a.app = app
         a.version = "head"
+        a.shortVersionString = shortVersionString
         a.notes = app.notes
         a.published_at = published_at
         a.object = object.copy(:key => a.object_name)

--- a/lib/glitter/templates/Glitterfile
+++ b/lib/glitter/templates/Glitterfile
@@ -1,6 +1,7 @@
 # After you configure this file, deploy your app with `glitter push`
 name          "My App"
 version       "1.0.0"
+shortVersionString "1.0"
 archive       "my_app.zip"
 notes         "notes go here"
 

--- a/lib/glitter/templates/rss.xml.erb
+++ b/lib/glitter/templates/rss.xml.erb
@@ -6,7 +6,7 @@
 <language>en</language>
 <% app.assets.each do |version, asset| %>
 <item>
-  <title>Version <%= version %></title>
+  <title>Version <%= asset.shortVersionString %></title>
   <description>
     <![CDATA[
       <h2>New Features</h2>
@@ -14,7 +14,7 @@
     ]]>
   </description>
   <pubDate><%= asset.published_at.strftime("%a, %d %b %Y %H:%M:%S %z") %></pubDate>
-  <enclosure url="<%= asset.url %>" sparkle:version="<%= version %>" length="<%= asset.file.stat.size %>" type="application/octet-stream" />
+  <enclosure url="<%= asset.url %>" sparkle:version="<%= version %>" sparkle:shortVersionString="<%= asset.shortVersionString %>" length="<%= asset.file.stat.size %>" type="application/octet-stream" />
 </item>
 <% end %>
 </channel>

--- a/lib/glitter/version.rb
+++ b/lib/glitter/version.rb
@@ -1,3 +1,3 @@
 module Glitter
-  VERSION = "0.0.91"
+  VERSION = "0.0.92"
 end

--- a/spec/lib/glitter_spec.rb
+++ b/spec/lib/glitter_spec.rb
@@ -6,6 +6,7 @@ describe Glitter::App do
     @app = Glitter::App.configure do
       name          "My App"
       version       "1.0.0"
+      shortVersionString "1.0"
       archive       "lib/glitter.rb"
       
       s3 {
@@ -43,6 +44,10 @@ describe Glitter::App do
       @config.version.should eql("1.0.0")
     end
 
+    it "should read shortVersionString" do
+      @config.shortVersionString.should eql("1.0")
+    end
+
     it "should read archive" do
       @config.archive.should eql("my_app.zip")
     end
@@ -75,6 +80,7 @@ describe Glitter::App do
       @config = Glitter::App.configure do
         name          "My App"
         version       "1.0.0"
+        shortVersionString  "1.0"
         archive       "my_app.zip"
         notes         "notes go here"
 


### PR DESCRIPTION
Added support for shortVersionString. Most Glitter implementations have a marketing label eg: 1.0 and an internal build number eg: 1.12.123
