### PR TITLE
add support for minimum system version

### DIFF
--- a/lib/glitter/cli.rb
+++ b/lib/glitter/cli.rb
@@ -9,8 +9,10 @@ module Glitter
     method_option :notes,           :type => :string, :aliases => "-n"
     method_option :force,           :type => :boolean, :aliases => "-f"
     method_option :bundle_version,  :type => :string, :aliases => "-b"
+    method_option :minimum_system_version, :type => :string, :aliases => "-m"
     def push(executable_path, *asset_paths)
       release = Release::Sparkle.new(channel, options.version)
+      release.minimum_system_version = options.minimum_system_version
       release.bundle_version = options.bundle_version
       release.notes       = options.notes
       release.executable  = File.open executable_path

--- a/lib/glitter/release.rb
+++ b/lib/glitter/release.rb
@@ -70,7 +70,7 @@ module Glitter
     # lives inside of a channel.
     class Sparkle < Base
       attr_accessor :notes, :executable, :filename
-      attr_writer   :published_at, :bundle_version
+      attr_writer   :published_at, :bundle_version, :minimum_system_version
 
       # Yeah, lets publish this shiz NOW.
       def published_at
@@ -87,6 +87,12 @@ module Glitter
 
       def bundle_version
         @bundle_version || @version
+      end
+
+      def minimum_version_attribute
+        unless @minimum_system_version.nil?
+          "<sparkle:minimumSystemVersion>#{@minimum_system_version}</sparkle:minimumSystemVersion>"
+        end
       end
 
     private

--- a/lib/glitter/templates/appcast.xml.erb
+++ b/lib/glitter/templates/appcast.xml.erb
@@ -8,6 +8,7 @@
     <item>
       <title>Version <%= version %></title>
       <sparkle:releaseNotesLink><%= notes_asset.url %></sparkle:releaseNotesLink>
+      <%= minimum_version_attribute %>
       <description>
         <![CDATA[
           <%= notes %>

--- a/spec/lib/glitter_spec.rb
+++ b/spec/lib/glitter_spec.rb
@@ -10,6 +10,7 @@ describe Glitter do
     Glitter::Release::Sparkle.new server.channel('test-channel'), "1.1.2-#{rand}" do |r|
       r.executable = File.open(__FILE__)
       r.notes = %[Did you know that its #{Time.now}? Wait, you can only answer yes to that question.]
+      r.minimum_system_version = Time.now
     end.push.head
   end
 end


### PR DESCRIPTION
Add support for required system version with

``` xml
<sparkle:minimumSystemVersion>1.1.1</sparkle:minimumSystemVersion>
```
