### PR TITLE
2.2.1

### DIFF
--- a/glitter.gemspec
+++ b/glitter.gemspec
@@ -13,10 +13,9 @@ Gem::Specification.new do |s|
   s.description = %q{Glitter makes it easy to publish software updates via the Sparkle framework by using S3 buckets.}
   s.licenses    = ['MIT']
 
-  s.rubyforge_project = "glitter"
   s.required_ruby_version = ">= 2.0.0"
   s.add_dependency "s3", "~> 0.3"
-  s.add_dependency "haml", "~> 3.0"
+  s.add_dependency "haml", "~> 5.0"
   s.add_dependency "thor", "~> 1.0"
   
   s.files         = `git ls-files`.split("\n")

--- a/lib/glitter/version.rb
+++ b/lib/glitter/version.rb
@@ -1,3 +1,3 @@
 module Glitter
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end


### PR DESCRIPTION
This PR updates to the haml dependency relative to the current version.
haml 3 has a cross scripting security issue with ruby. To avoid glitter
installing an insecure of version haml where this is the only gem with a
haml dependency, the version is set to ~>5. This also removes the
deprecated `rubyforge_project` property in the gemspec.